### PR TITLE
Wait for fs operations in registerDir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 all.config
 build
 
+# IDE files
+.idea
+
 # Logs
 logs
 *.log

--- a/index.js
+++ b/index.js
@@ -18,29 +18,29 @@ module.exports = function () {
   }
 
   function registerDir(dir, prefix) {
-    fs.readdir(dir, function(err, serviceDirectories) {
-      if (err) {
-        const error = `Can not register directory: ${dir} ${err}`;
-        throw new Error(error);
+    const serviceDirectories = fs.readdirSync(dir);
+    _.forEach(serviceDirectories, function (serviceDirectory) {
+      const servicePath = [dir, serviceDirectory].join('/');
+      if (prefix) {
+        const basename = path.basename(serviceDirectory, '.js');
+        serviceDirectory = `${prefix}-${basename}`;
       }
+      if(serviceDirectory.indexOf('lab-') !== 0) {
+        return;
+      }
+      registerModule(servicePath, serviceDirectory);
+      const impDir = [servicePath, 'implementations'].join('/');
 
-      _.forEach(serviceDirectories, function (serviceDirectory){
-        const servicePath = [dir, serviceDirectory].join('/');
-        if (prefix) {
-          const basename = path.basename(serviceDirectory, '.js');
-          serviceDirectory = `${prefix}-${basename}`;
+      try {
+        fs.accessSync(impDir);
+        registerDir(impDir, serviceDirectory)
+      } catch(err) {
+        if (err.code === 'ENOENT' || err.code === 'ENOTDIR') {
+          console.log(`Could not register ${impDir} due to ${err.code}.`);
+        } else {
+          throw err;
         }
-        if(serviceDirectory.indexOf('lab-') !== 0) {
-          return;
-        }
-        registerModule(servicePath, serviceDirectory);
-        const impDir = [servicePath, 'implementations'].join('/')
-        fs.access(impDir, function(nonexistent) {
-          if (!nonexistent) {
-            registerDir(impDir, serviceDirectory)
-          }
-        });
-      });
+      }
     });
   }
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,6 @@
     "lodash": "^4.14.1"
   },
   "devDependencies": {
-    "cucumber": "^1.2.1"
+    "cucumber": "^1.3.0"
   }
 }


### PR DESCRIPTION
Either this, or promisifying this method is required in order to use lab-di
in our projects without the build sometimes breaking.
If we want to make this method async, then we have to wait for it in every
project we use it in, so it should be decided early in order to avoid the necessity
of any dependant packages' refactor.